### PR TITLE
Safari mobile browser bug fix

### DIFF
--- a/_calendar-tasty.scss
+++ b/_calendar-tasty.scss
@@ -296,7 +296,7 @@ body.chopping .badge-secondary{
         width: auto;
         margin-right: unset !important;
         resize: both;
-        display: flex;
+        display: block;
         height: auto;
         min-height: unset !important;
 


### PR DESCRIPTION
Under 520px width > change image wrapper to display:block from flex.  Fixes vertical stretching.